### PR TITLE
A faster and lower memory generate.cpp

### DIFF
--- a/src/lib/gaussquad.cpp
+++ b/src/lib/gaussquad.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "gaussquad.hpp"
+#include <cassert>
 #include <cmath>
 #include <iostream>
 


### PR DESCRIPTION
For DLIBECPINT_MAX_L=7 github workflow machines cannot handle memory requirements.

The generate script accumulates a std::vector<tuple<int, int, int>>, then sorts them and then erases duplicates. This vector gets very big.

Changing to a `std::set<tuple<int, int, int>>` we get the sort and erase baked in to the container.

I was unsure exactly how the unrolling works so early exiting is only performed when `unrolling=false`